### PR TITLE
fixing how to create an admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - you need JDK 7 or 8 and Maven
 - from the top-level of infinispan ($ISPN_HOME) run: `./build.sh clean package -DskipTests`
 - cd $ISPN_HOME/server/integration/build/target/infinispan-server-*
-- run `./bin/add-user.sh -u admin '!qazxsw2'` to create an admin user
+- run `./bin/add-user.sh -u admin -p !qazxsw2 -g admin` to create an admin user
 
 #  Running web application
 - run server by going to $ISPN_HOME/server/integration/build/target/infinispan-server-* and running `./bin/domain.sh`


### PR DESCRIPTION
The command ./bin/add-user.sh -u admin '!qazxsw2' doesn't create an admin user, so with that command when try to access the GUI application infinispan-management-console on development mode the user receive:
```java.lang.SecurityException:` ISPN000287: Unauthorized access: subject 'Subject with principal(s): [org.jboss.as.core.security.SimplePrincipal@16d39cab, gustavo@ManagementRealm, InetAddressPrincipal <127.0.0.1/127.0.0.1>]' lacks 'ADMIN' permission```